### PR TITLE
Update OneDrive Explorer to use Graph directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # onedrive-explorer-android
-[![Build Status](https://travis-ci.org/OneDrive/onedrive-explorer-android.svg?branch=master)](https://travis-ci.org/OneDrive/onedrive-explorer-android)
+[![Build Status](https://travis-ci.org/microsoftgraph/onedrive-explorer-android.svg?branch=master)](https://travis-ci.org/microsoftgraph/onedrive-explorer-android)
 
 OneDrive API Explorer for Android Phone and Tablets
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 OneDrive API Explorer for Android Phone and Tablets
 
-This sample illustrates basic concepts for interacting with the OneDrive API
-from an Android application using the [OneDrive SDK for Android](https://github.com/OneDrive/onedrive-sdk-android).
+This sample illustrates basic concepts for interacting with the [Microsoft Graph API](http://graph.microsoft.io/en-us/) with OneDrive
+from an Android application using the [Microsoft Graph SDK for Android](https://github.com/microsoftgraph/msgraph-sdk-android).
 
 Included in this project:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     // Include the sdk as a dependency
-    compile 'com.microsoft.graph:msa-auth-for-android-adapter:0.9.0'
+    compile 'com.microsoft.graph:msa-auth-for-android-adapter:0.9.+'
 
     // Include the gson dependency
     compile 'com.google.code.gson:gson:2.3.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,11 +37,11 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     // Include the sdk as a dependency
-    compile('com.onedrive.sdk:onedrive-sdk-android:1.1.+')
+    compile 'com.microsoft.graph:msa-auth-for-android-adapter:0.9.0'
 
     // Include the gson dependency
     compile 'com.google.code.gson:gson:2.3.1'
 
     // Include supported authentication methods for your application
-    compile 'com.microsoft.services.msa:msa-auth:0.8.4'
+    compile 'com.microsoft.services.msa:msa-auth:0.8.7+'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,13 +36,19 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-    // Include the sdk as a dependency
-    compile 'com.microsoft.graph:msgraph-sdk-android:0.9.2-SNAPSHOT'
-    compile 'com.microsoft.graph:msa-auth-for-android-adapter:0.9.+'
+    // Android SDK for Graph
+    compile ('com.microsoft.graph:msgraph-sdk-android:0.9.+') {
+        transitive = false
+    }
+
+    // MSGraph MSA-Auth-for-Android-Adapter
+    compile ('com.microsoft.graph:msa-auth-for-android-adapter:0.9.+') {
+        transitive = false;
+    }
 
     // Include the gson dependency
-    compile 'com.google.code.gson:gson:2.3.1'
+    compile ('com.google.code.gson:gson:2.3.1')
 
     // Include supported authentication methods for your application
-    compile 'com.microsoft.services.msa:msa-auth:0.8.+'
+    compile ('com.microsoft.services.msa:msa-auth:0.8.+')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,5 +43,5 @@ dependencies {
     compile 'com.google.code.gson:gson:2.3.1'
 
     // Include supported authentication methods for your application
-    compile 'com.microsoft.services.msa:msa-auth:0.8.7+'
+    compile 'com.microsoft.services.msa:msa-auth:0.8.+'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     // Include the sdk as a dependency
+    compile 'com.microsoft.graph:msgraph-sdk-android:0.9.2-SNAPSHOT'
     compile 'com.microsoft.graph:msa-auth-for-android-adapter:0.9.+'
 
     // Include the gson dependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
     // Include the sdk as a dependency
-    compile('com.onedrive.sdk:onedrive-sdk-android:+')
+    compile('com.onedrive.sdk:onedrive-sdk-android:1.1.+')
 
     // Include the gson dependency
     compile 'com.google.code.gson:gson:2.3.1'

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -139,7 +139,7 @@ public class BaseApplication extends Application {
             }
 
             @Override
-            public void failure(ClientException ex) {
+            public void failure(final ClientException ex) {
                 Toast.makeText(getBaseContext(), "Logout error " + ex, Toast.LENGTH_LONG).show();
             }
         });

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -90,7 +90,7 @@ public class BaseApplication extends Application {
             @Override
             public String[] getScopes() {
                 return new String[] {
-                        "https://graph.microsoft.com/Files.Read",
+                        "https://graph.microsoft.com/Files.ReadWrite",
                         "offline_access",
                         "openid"
                 };

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/BaseApplication.java
@@ -33,6 +33,7 @@ import android.provider.Settings;
 import android.util.LruCache;
 import android.widget.Toast;
 
+import com.onedrive.sdk.authentication.ADALAuthenticator;
 import com.onedrive.sdk.authentication.MSAAuthenticator;
 import com.onedrive.sdk.concurrency.ICallback;
 import com.onedrive.sdk.core.ClientException;
@@ -94,8 +95,19 @@ public class BaseApplication extends Application {
                 return new String[] {"onedrive.readwrite", "onedrive.appfolder", "wl.offline_access"};
             }
         };
+        final ADALAuthenticator adalAuthenticator = new ADALAuthenticator() {
+            @Override
+            protected String getClientId() {
+                return "b26aadf8-566f-4478-926f-589f601d9c74";
+            }
 
-        final IClientConfig config = DefaultClientConfig.createWithAuthenticator(msaAuthenticator);
+            @Override
+            protected String getRedirectUrl() {
+                return "msauth://com.microsoft.skydrive/ODD3OR3tCemNTgxEX1K6yZVHByw%3D";
+            }
+        };
+
+        final IClientConfig config = DefaultClientConfig.createWithAuthenticators(msaAuthenticator, adalAuthenticator);
         config.getLogger().setLoggingLevel(LoggerLevel.Debug);
         return config;
     }

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DefaultCallback.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DefaultCallback.java
@@ -27,8 +27,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.util.Log;
 
-import com.onedrive.sdk.concurrency.ICallback;
-import com.onedrive.sdk.core.ClientException;
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.core.ClientException;
 
 /**
  * A default callback that logs errors

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
@@ -151,8 +151,8 @@ public class DeltaFragment extends Fragment {
             .getMe()
             .getDrive()
             .getItems(mItemId)
-            .getDelta() // TODO: overloads are not being created properly.
-                .buildRequest()
+            .getDelta() // TODO: SERVICE overloads are not being created properly.
+            .buildRequest()
             .select("id,name,deleted")
             .get(pageHandler());
     }
@@ -200,7 +200,9 @@ public class DeltaFragment extends Fragment {
                 view.findViewById(android.R.id.progress).setVisibility(View.INVISIBLE);
                 jsonView.setVisibility(View.VISIBLE);
                 if (page.getNextPage() != null) {
-                    // TODO: It looks like next page is broken
+                    page.getNextPage()
+                        .buildRequest()
+                        .get(pageHandler());
                 }
                 final JsonElement deltaToken = page.getRawObject().get("@delta.token");
                 if (deltaToken != null) {

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
@@ -24,9 +24,9 @@ package com.microsoft.onedrive.apiexplorer;
 
 import com.google.gson.JsonElement;
 
-import com.onedrive.sdk.concurrency.ICallback;
-import com.onedrive.sdk.extensions.IDeltaCollectionPage;
-import com.onedrive.sdk.extensions.Item;
+import com.microsoft.graph.extensions.DriveItem;
+import com.microsoft.graph.extensions.IDriveItemDeltaCollectionPage;
+import com.microsoft.graph.concurrency.ICallback;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -89,7 +89,7 @@ public class DeltaFragment extends Fragment {
      * @param item the item
      * @return The fragment
      */
-    static DeltaFragment newInstance(final Item item) {
+    static DeltaFragment newInstance(final DriveItem item) {
         final DeltaFragment fragment = new DeltaFragment();
         final Bundle args = new Bundle();
         args.putString(ARG_ITEM_ID, item.id);
@@ -147,11 +147,12 @@ public class DeltaFragment extends Fragment {
         final String deltaToken = getDeltaInfo().getString(mItemId, null);
         final Activity activity = getActivity();
         ((BaseApplication) activity.getApplication())
-            .getOneDriveClient()
+            .getGraphServiceClient()
+            .getMe()
             .getDrive()
             .getItems(mItemId)
-            .getDelta(deltaToken)
-            .buildRequest()
+            .getDelta() // TODO: overloads are not being created properly.
+                .buildRequest()
             .select("id,name,deleted")
             .get(pageHandler());
     }
@@ -160,10 +161,10 @@ public class DeltaFragment extends Fragment {
      * Create a handler for downloaded pages
      * @return The callback to handle a fresh DeltaPage
      */
-    private ICallback<IDeltaCollectionPage> pageHandler() {
-        return new DefaultCallback<IDeltaCollectionPage>(getActivity()) {
+    private ICallback<IDriveItemDeltaCollectionPage> pageHandler() {
+        return new DefaultCallback<IDriveItemDeltaCollectionPage>(getActivity()) {
             @Override
-            public void success(final IDeltaCollectionPage page) {
+            public void success(final IDriveItemDeltaCollectionPage page) {
                 final View view = getView();
                 if (view == null) {
                     return;
@@ -182,7 +183,7 @@ public class DeltaFragment extends Fragment {
                 final TextView jsonView = (TextView) viewById;
                 final CharSequence originalText = jsonView.getText();
                 final StringBuilder sb = new StringBuilder(originalText);
-                for (final Item i : page.getCurrentPage()) {
+                for (final DriveItem i : page.getCurrentPage()) {
                     try {
                         final int indentSpaces = 3;
                         sb.append(new JSONObject(i.getRawObject().toString()).toString(indentSpaces));
@@ -199,9 +200,7 @@ public class DeltaFragment extends Fragment {
                 view.findViewById(android.R.id.progress).setVisibility(View.INVISIBLE);
                 jsonView.setVisibility(View.VISIBLE);
                 if (page.getNextPage() != null) {
-                    page.getNextPage()
-                        .buildRequest()
-                        .get(pageHandler());
+                    // TODO: It looks like next page is broken
                 }
                 final JsonElement deltaToken = page.getRawObject().get("@delta.token");
                 if (deltaToken != null) {

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DeltaFragment.java
@@ -151,7 +151,7 @@ public class DeltaFragment extends Fragment {
             .getMe()
             .getDrive()
             .getItems(mItemId)
-            .getDelta() // TODO: SERVICE overloads are not being created properly.
+            .getDelta() // TODO: SERVICE does not accept tokens.
             .buildRequest()
             .select("id,name,deleted")
             .get(pageHandler());

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItem.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItem.java
@@ -22,15 +22,14 @@
 
 package com.microsoft.onedrive.apiexplorer;
 
-import com.microsoft.graph.extensions.DriveItem;
-import com.microsoft.graph.extensions.IGraphServiceClient;
-import com.microsoft.graph.extensions.ThumbnailRequestBuilder;
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.util.LruCache;
+
+import com.microsoft.graph.extensions.DriveItem;
+import com.microsoft.graph.extensions.IGraphServiceClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -93,12 +92,11 @@ class DisplayItem {
                     InputStream in = null;
                     try {
                         final IGraphServiceClient graphServiceClient = base.getGraphServiceClient();
-                        final String requestUrl = graphServiceClient
+                        in = graphServiceClient
                                 .getDrive()
                                 .getItems(mId)
                                 .getThumbnails("0")
-                                .getRequestUrl();
-                        in = new ThumbnailRequestBuilder(requestUrl + "/small", graphServiceClient, null) // TODO: Add getThumbnailSize helper
+                                .getThumbnailSize("small")
                                 .getContent()
                                 .buildRequest()
                                 .get();

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItem.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/DisplayItem.java
@@ -22,7 +22,9 @@
 
 package com.microsoft.onedrive.apiexplorer;
 
-import com.onedrive.sdk.extensions.Item;
+import com.microsoft.graph.extensions.DriveItem;
+import com.microsoft.graph.extensions.IGraphServiceClient;
+import com.microsoft.graph.extensions.ThumbnailRequestBuilder;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -48,7 +50,7 @@ class DisplayItem {
     /**
      * The actual backing item instance
      */
-    private final Item mItem;
+    private final DriveItem mItem;
 
     /**
      * The id for this display item
@@ -69,7 +71,7 @@ class DisplayItem {
      * @param imageCache The thumbnail image cache
      */
     public DisplayItem(final DisplayItemAdapter adapter,
-                       final Item item,
+                       final DriveItem item,
                        final String id,
                        final LruCache<String, Bitmap> imageCache) {
         mImageCache = imageCache;
@@ -90,11 +92,13 @@ class DisplayItem {
 
                     InputStream in = null;
                     try {
-                        in = base.getOneDriveClient()
+                        final IGraphServiceClient graphServiceClient = base.getGraphServiceClient();
+                        final String requestUrl = graphServiceClient
                                 .getDrive()
                                 .getItems(mId)
                                 .getThumbnails("0")
-                                .getThumbnailSize("small")
+                                .getRequestUrl();
+                        in = new ThumbnailRequestBuilder(requestUrl + "/small", graphServiceClient, null) // TODO: Add getThumbnailSize helper
                                 .getContent()
                                 .buildRequest()
                                 .get();
@@ -140,7 +144,7 @@ class DisplayItem {
      * The backing item instance
      * @return The item instance
      */
-    public Item getItem() {
+    public DriveItem getItem() {
         return mItem;
     }
 

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
@@ -259,7 +259,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 menu.findItem(R.id.action_copy).setVisible(true);
             }
 
-            menu.findItem(R.id.action_copy).setVisible(false); // TODO: Copy isn't supported in graph at the moment
+            menu.findItem(R.id.action_copy).setVisible(false); // TODO: SERVICE DriveItems copy isn't supported in graph at the moment
         }
     }
 
@@ -459,7 +459,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                     final BaseApplication application = (BaseApplication) getActivity()
                                                                               .getApplication();
                     application.getGraphServiceClient()
-                        .getMe()
+                            .getMe()
                         .getDrive()
                         .getItems(item.id)
                         .buildRequest()
@@ -506,26 +506,26 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         final BaseApplication application = (BaseApplication) getActivity()
                                                                                   .getApplication();
                         application.getGraphServiceClient()
-                            .getMe()
+                                .getMe()
                             .getDrive()
                             .getItems(item.id)
                             .getCreateLink(items[selection.get()].toString(), null) // TODO: Figure out what that should be
                             .buildRequest()
-                            .post(new DefaultCallback<Permission>(getActivity()) {
-                                @Override
-                                public void success(final Permission permission) {
-                                    final ClipboardManager cm = (ClipboardManager)
-                                            getActivity()
-                                                    .getSystemService(Context.CLIPBOARD_SERVICE);
-                                    final ClipData data =
-                                            ClipData.newPlainText("Link Url", permission.link.webUrl);
-                                    cm.setPrimaryClip(data);
-                                    Toast.makeText(getActivity(),
-                                            application.getString(R.string.created_link),
-                                            Toast.LENGTH_LONG).show();
-                                    getActivity().onBackPressed();
-                                }
-                            });
+                                .post(new DefaultCallback<Permission>(getActivity()) {
+                                    @Override
+                                    public void success(final Permission permission) {
+                                        final ClipboardManager cm = (ClipboardManager)
+                                                getActivity()
+                                                        .getSystemService(Context.CLIPBOARD_SERVICE);
+                                        final ClipData data =
+                                                ClipData.newPlainText("Link Url", permission.link.webUrl);
+                                        cm.setPrimaryClip(data);
+                                        Toast.makeText(getActivity(),
+                                                application.getString(R.string.created_link),
+                                                Toast.LENGTH_LONG).show();
+                                        getActivity().onBackPressed();
+                                    }
+                                });
                     }
                 })
                 .setSingleChoiceItems(items, 0, new DialogInterface.OnClickListener() {
@@ -586,11 +586,11 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                     updatedItem.name = newName.getText().toString();
                     ((BaseApplication) activity.getApplication())
                         .getGraphServiceClient()
-                        .getMe()
+                            .getMe()
                         .getDrive()
                         .getItems(updatedItem.id)
                         .buildRequest()
-                        .patch(updatedItem, callback);
+                            .patch(updatedItem, callback);
                 }
             })
             .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
@@ -651,12 +651,12 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
 
                         ((BaseApplication) activity.getApplication())
                             .getGraphServiceClient()
-                            .getMe()
+                                .getMe()
                             .getDrive()
                             .getItems(mItemId)
                             .getChildren()
                             .buildRequest()
-                            .post(newItem, callback);
+                                .post(newItem, callback);
                     }
                 })
                 .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -846,7 +846,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         .getMe()
                         .getDrive()
                             .getItems(item.id)
-// TODO Add extension                        .getItemWithPath(itemPath.getText().toString())
+                            .getItemWithPath(itemPath.getText().toString())
                             .buildRequest()
                         .expand(getExpansionOptions())
                         .get(itemCallback);

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
@@ -22,21 +22,6 @@
 
 package com.microsoft.onedrive.apiexplorer;
 
-import com.onedrive.sdk.concurrency.AsyncMonitor;
-import com.onedrive.sdk.concurrency.ICallback;
-import com.onedrive.sdk.concurrency.IProgressCallback;
-import com.onedrive.sdk.core.ClientException;
-import com.onedrive.sdk.core.OneDriveErrorCodes;
-import com.onedrive.sdk.extensions.Folder;
-import com.onedrive.sdk.extensions.IOneDriveClient;
-import com.onedrive.sdk.extensions.Item;
-import com.onedrive.sdk.extensions.ItemReference;
-import com.onedrive.sdk.extensions.Permission;
-import com.onedrive.sdk.options.Option;
-import com.onedrive.sdk.options.QueryOption;
-
-import org.json.JSONObject;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
@@ -53,7 +38,6 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.text.InputType;
 import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
@@ -70,6 +54,19 @@ import android.widget.EditText;
 import android.widget.RadioButton;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import com.microsoft.graph.concurrency.ICallback;
+import com.microsoft.graph.concurrency.IProgressCallback;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.core.GraphErrorCodes;
+import com.microsoft.graph.extensions.DriveItem;
+import com.microsoft.graph.extensions.Folder;
+import com.microsoft.graph.extensions.IGraphServiceClient;
+import com.microsoft.graph.extensions.Permission;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.options.QueryOption;
+
+import org.json.JSONObject;
 
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -129,7 +126,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
     /**
      * The backing item representation
      */
-    private Item mItem;
+    private DriveItem mItem;
 
     /**
      * The listener for interacting with this fragment
@@ -262,6 +259,8 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 menu.findItem(R.id.action_copy).setVisible(true);
             }
         }
+
+        menu.findItem(R.id.action_copy).setVisible(false); // TODO: Copy isn't supported in graph at the moment
     }
 
     @Override
@@ -272,7 +271,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
 
         switch (item.getItemId()) {
             case R.id.action_copy:
-                copy(mItem);
+//                copy(mItem);
                 return true;
             case R.id.action_set_copy_destination:
                 setCopyDestination(mItem);
@@ -313,74 +312,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Sets the copy destination within the preferences
      * @param item The item to mark as the destination
      */
-    private void setCopyDestination(final Item item) {
+    private void setCopyDestination(final DriveItem item) {
         getCopyPrefs().edit().putString(COPY_DESTINATION_PREF_KEY, item.id).commit();
         getActivity().invalidateOptionsMenu();
-    }
-
-    /**
-     * Copies an item onto the current destination in the copy preferences
-     * @param item The item to copy
-     */
-    private void copy(final Item item) {
-        final BaseApplication app = (BaseApplication) getActivity().getApplication();
-        final IOneDriveClient oneDriveClient = app.getOneDriveClient();
-        final ItemReference parentReference = new ItemReference();
-        parentReference.id = getCopyPrefs().getString(COPY_DESTINATION_PREF_KEY, null);
-
-        final ProgressDialog dialog = new ProgressDialog(getActivity(), ProgressDialog.STYLE_HORIZONTAL);
-        dialog.setTitle("Copying item");
-        dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        dialog.setMessage("Waiting for copy to complete");
-
-        final IProgressCallback<Item> progressCallback = new IProgressCallback<Item>() {
-            @Override
-            public void progress(final long current, final long max) {
-                dialog.setMax((int)current);
-                dialog.setMax((int) max);
-            }
-
-            @Override
-            public void success(final Item item) {
-                dialog.dismiss();
-                final String string = getString(R.string.copy_success_message,
-                                                item.name,
-                                                item.parentReference.path);
-                Toast.makeText(getActivity(), string, Toast.LENGTH_LONG).show();
-            }
-
-            @Override
-            public void failure(final ClientException error) {
-                dialog.dismiss();
-                new AlertDialog.Builder(getActivity())
-                    .setTitle(R.string.error_title)
-                    .setMessage(error.getMessage())
-                    .setNegativeButton(R.string.close, new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(final DialogInterface dialog, final int which) {
-                            dialog.dismiss();
-                        }
-                    })
-                    .create()
-                    .show();
-            }
-        };
-
-        final DefaultCallback<AsyncMonitor<Item>> callback
-            = new DefaultCallback<AsyncMonitor<Item>>(getActivity()) {
-            @Override
-            public void success(final AsyncMonitor<Item> itemAsyncMonitor) {
-                final int millisBetweenPoll = 1000;
-                itemAsyncMonitor.pollForResult(millisBetweenPoll, progressCallback);
-            }
-        };
-        oneDriveClient
-            .getDrive()
-            .getItems(item.id)
-            .getCopy(item.name, parentReference)
-            .buildRequest()
-            .create(callback);
-        dialog.show();
     }
 
     @Override
@@ -403,10 +337,10 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * @param context The application context to display messages
      * @return The callback to refresh this item with
      */
-    private ICallback<Item> getItemCallback(final BaseApplication context) {
-        return new DefaultCallback<Item>(context) {
+    private ICallback<DriveItem> getItemCallback(final BaseApplication context) {
+        return new DefaultCallback<DriveItem>(context) {
             @Override
-            public void success(final Item item) {
+            public void success(final DriveItem item) {
                 mItem = item;
                 if (getView() != null) {
                     final AbsListView mListView = (AbsListView) getView().findViewById(android.R.id.list);
@@ -449,7 +383,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         setFocus(ItemFocus.Empty, getView());
 
                     } else {
-                        for (final Item childItem : item.children.getCurrentPage()) {
+                        for (final DriveItem childItem : item.children.getCurrentPage()) {
                             adapter.add(new DisplayItem(adapter,
                                                         childItem,
                                                         childItem.id,
@@ -482,8 +416,8 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
         mItem = null;
 
         final BaseApplication app = (BaseApplication) getActivity().getApplication();
-        final IOneDriveClient oneDriveClient = app.getOneDriveClient();
-        final ICallback<Item> itemCallback = getItemCallback(app);
+        final IGraphServiceClient graphServiceClient = app.getGraphServiceClient();
+        final ICallback<DriveItem> itemCallback = getItemCallback(app);
 
         final String itemId;
         if (mItemId.equals("root")) {
@@ -492,40 +426,29 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
             itemId = mItemId;
         }
 
-        oneDriveClient
+        graphServiceClient
+            .getMe()
             .getDrive()
             .getItems(itemId)
             .buildRequest()
-            .expand(getExpansionOptions(oneDriveClient))
+            .expand(getExpansionOptions())
             .get(itemCallback);
     }
 
     /**
      * Gets the expansion options for requests on items
      * @see {https://github.com/OneDrive/onedrive-api-docs/issues/203}
-     * @param oneDriveClient the OneDrive client
      * @return The string for expand options
      */
-    @NonNull
-    private String getExpansionOptions(final IOneDriveClient oneDriveClient) {
-        final String expansionOption;
-        switch (oneDriveClient.getAuthenticator().getAccountInfo().getAccountType()) {
-            case MicrosoftAccount:
-                expansionOption = EXPAND_OPTIONS_FOR_CHILDREN_AND_THUMBNAILS;
-                break;
-
-            default:
-                expansionOption = EXPAND_OPTIONS_FOR_CHILDREN_AND_THUMBNAILS_LIMITED;
-                break;
-        }
-        return expansionOption;
+    private String getExpansionOptions() {
+        return EXPAND_OPTIONS_FOR_CHILDREN_AND_THUMBNAILS;
     }
 
     /**
      * Deletes the item represented by this fragment
      * @param item The item to delete
      */
-    private void deleteItem(final Item item) {
+    private void deleteItem(final DriveItem item) {
         final AlertDialog alertDialog = new AlertDialog.Builder(getActivity())
             .setTitle(R.string.delete)
             .setIcon(android.R.drawable.ic_delete)
@@ -535,7 +458,8 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 public void onClick(final DialogInterface dialog, final int which) {
                     final BaseApplication application = (BaseApplication) getActivity()
                                                                               .getApplication();
-                    application.getOneDriveClient()
+                    application.getGraphServiceClient()
+                        .getMe()
                         .getDrive()
                         .getItems(item.id)
                         .buildRequest()
@@ -565,7 +489,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Creates a link on this item
      * @param item The item to delete
      */
-    private void createLink(final Item item) {
+    private void createLink(final DriveItem item) {
         final CharSequence[] items = {"view", "edit"};
         final int nothingSelected = -1;
         final AtomicInteger selection = new AtomicInteger(nothingSelected);
@@ -581,23 +505,24 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
 
                         final BaseApplication application = (BaseApplication) getActivity()
                                                                                   .getApplication();
-                        application.getOneDriveClient()
+                        application.getGraphServiceClient()
+                            .getMe()
                             .getDrive()
                             .getItems(item.id)
-                            .getCreateLink(items[selection.get()].toString())
+                            .getCreateLink(items[selection.get()].toString(), null) // TODO: Figure out what that should be
                             .buildRequest()
-                            .create(new DefaultCallback<Permission>(getActivity()) {
+                            .post(new DefaultCallback<Permission>(getActivity()) {
                                 @Override
                                 public void success(final Permission permission) {
                                     final ClipboardManager cm = (ClipboardManager)
-                                                                    getActivity()
-                                                                        .getSystemService(Context.CLIPBOARD_SERVICE);
+                                            getActivity()
+                                                    .getSystemService(Context.CLIPBOARD_SERVICE);
                                     final ClipData data =
-                                        ClipData.newPlainText("Link Url", permission.link.webUrl);
+                                            ClipData.newPlainText("Link Url", permission.link.webUrl);
                                     cm.setPrimaryClip(data);
                                     Toast.makeText(getActivity(),
-                                                      application.getString(R.string.created_link),
-                                                      Toast.LENGTH_LONG).show();
+                                            application.getString(R.string.created_link),
+                                            Toast.LENGTH_LONG).show();
                                     getActivity().onBackPressed();
                                 }
                             });
@@ -623,7 +548,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Renames a sourceItem
      * @param sourceItem The sourceItem to rename
      */
-    private void renameItem(final Item sourceItem) {
+    private void renameItem(final DriveItem sourceItem) {
         final Activity activity = getActivity();
         final EditText newName = new EditText(activity);
         newName.setInputType(InputType.TYPE_CLASS_TEXT);
@@ -635,9 +560,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
             .setPositiveButton(R.string.rename, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(final DialogInterface dialog, final int which) {
-                    final ICallback<Item> callback = new DefaultCallback<Item>(getActivity()) {
+                    final ICallback<DriveItem> callback = new DefaultCallback<DriveItem>(getActivity()) {
                         @Override
-                        public void success(final Item item) {
+                        public void success(final DriveItem item) {
                             Toast.makeText(activity,
                                               activity
                                                   .getString(R.string.renamed_item, sourceItem.name,
@@ -656,15 +581,16 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                             dialog.dismiss();
                         }
                     };
-                    Item updatedItem = new Item();
+                    DriveItem updatedItem = new DriveItem();
                     updatedItem.id = sourceItem.id;
                     updatedItem.name = newName.getText().toString();
                     ((BaseApplication) activity.getApplication())
-                        .getOneDriveClient()
+                        .getGraphServiceClient()
+                        .getMe()
                         .getDrive()
                         .getItems(updatedItem.id)
                         .buildRequest()
-                        .update(updatedItem, callback);
+                        .patch(updatedItem, callback);
                 }
             })
             .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
@@ -681,7 +607,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Creates a folder
      * @param item The parent of the folder to create
      */
-    private void createFolder(final Item item) {
+    private void createFolder(final DriveItem item) {
         final Activity activity = getActivity();
         final EditText newName = new EditText(activity);
         newName.setInputType(InputType.TYPE_CLASS_TEXT);
@@ -694,9 +620,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 .setPositiveButton(R.string.create_folder, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(final DialogInterface dialog, final int which) {
-                        final ICallback<Item> callback = new DefaultCallback<Item>(activity) {
+                        final ICallback<DriveItem> callback = new DefaultCallback<DriveItem>(activity) {
                             @Override
-                            public void success(final Item createdItem) {
+                            public void success(final DriveItem createdItem) {
                                 Toast.makeText(activity,
                                                   activity.getString(R.string.created_folder,
                                                                         createdItem.name,
@@ -719,17 +645,18 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                             }
                         };
 
-                        final Item newItem = new Item();
+                        final DriveItem newItem = new DriveItem();
                         newItem.name = newName.getText().toString();
                         newItem.folder = new Folder();
 
                         ((BaseApplication) activity.getApplication())
-                            .getOneDriveClient()
+                            .getGraphServiceClient()
+                            .getMe()
                             .getDrive()
                             .getItems(mItemId)
                             .getChildren()
                             .buildRequest()
-                            .create(newItem, callback);
+                            .post(newItem, callback);
                     }
                 })
                 .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -756,7 +683,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         final BaseApplication application = (BaseApplication) getActivity().getApplication();
-        final IOneDriveClient oneDriveClient = application.getOneDriveClient();
+        final IGraphServiceClient graphServiceClient = application.getGraphServiceClient();
 
         if (requestCode == REQUEST_CODE_SIMPLE_UPLOAD
                 && data != null
@@ -784,7 +711,8 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         // Fix up the file name (needed for camera roll photos, etc)
                         final String filename = FileContent.getValidFileName(contentResolver, data.getData());
                         final Option option = new QueryOption("@name.conflictBehavior", "fail");
-                        oneDriveClient
+                        graphServiceClient
+                            .getMe()
                             .getDrive()
                             .getItems(mItemId)
                             .getChildren()
@@ -792,9 +720,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                             .getContent()
                             .buildRequest(Collections.singletonList(option))
                             .put(fileInMemory,
-                                new IProgressCallback<Item>() {
+                                new IProgressCallback<DriveItem>() {
                                     @Override
-                                    public void success(final Item item) {
+                                    public void success(final DriveItem item) {
                                         dialog.dismiss();
                                         Toast.makeText(getActivity(),
                                                           application
@@ -807,7 +735,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                                     @Override
                                     public void failure(final ClientException error) {
                                         dialog.dismiss();
-                                        if (error.isError(OneDriveErrorCodes.NameAlreadyExists)) {
+                                        if (error.isError(GraphErrorCodes.NameAlreadyExists)) {
                                             Toast.makeText(getActivity(),
                                                            R.string.upload_failed_name_conflict,
                                                            Toast.LENGTH_LONG).show();
@@ -841,7 +769,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Downloads this item
      * @param item The item to download
      */
-    private void download(final Item item) {
+    private void download(final DriveItem item) {
         final Activity activity = getActivity();
         final DownloadManager downloadManager = (DownloadManager) activity.getSystemService(Context
                 .DOWNLOAD_SERVICE);
@@ -863,7 +791,7 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Starts up a new View Delta viewer
      * @param item The item to delta over
      */
-    private void viewDelta(final Item item) {
+    private void viewDelta(final DriveItem item) {
         final DeltaFragment fragment = DeltaFragment.newInstance(item);
         navigateToFragment(fragment);
     }
@@ -885,17 +813,17 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * Navigates to an item by path
      * @param item the source item
      */
-    private void navigateByPath(final Item item) {
+    private void navigateByPath(final DriveItem item) {
         final BaseApplication application = (BaseApplication) getActivity().getApplication();
-        final IOneDriveClient oneDriveClient = application.getOneDriveClient();
+        final IGraphServiceClient graphServiceClient = application.getGraphServiceClient();
         final Activity activity = getActivity();
 
         final EditText itemPath = new EditText(activity);
         itemPath.setInputType(InputType.TYPE_CLASS_TEXT);
 
-        final DefaultCallback<Item> itemCallback = new DefaultCallback<Item>(activity) {
+        final DefaultCallback<DriveItem> itemCallback = new DefaultCallback<DriveItem>(activity) {
             @Override
-            public void success(final Item item) {
+            public void success(final DriveItem item) {
                 final ItemFragment fragment = ItemFragment.newInstance(item.id);
                 navigateToFragment(fragment);
             }
@@ -914,12 +842,13 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
             .setPositiveButton(R.string.navigate, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(final DialogInterface dialog, final int which) {
-                    oneDriveClient
+                    graphServiceClient
+                        .getMe()
                         .getDrive()
-                        .getItems(item.id)
-                        .getItemWithPath(itemPath.getText().toString())
-                        .buildRequest()
-                        .expand(getExpansionOptions(oneDriveClient))
+                            .getItems(item.id)
+// TODO Add extension                        .getItemWithPath(itemPath.getText().toString())
+                            .buildRequest()
+                        .expand(getExpansionOptions())
                         .get(itemCallback);
                 }
             })

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
@@ -258,9 +258,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 menu.findItem(R.id.action_download).setVisible(true);
                 menu.findItem(R.id.action_copy).setVisible(true);
             }
-        }
 
-        menu.findItem(R.id.action_copy).setVisible(false); // TODO: Copy isn't supported in graph at the moment
+            menu.findItem(R.id.action_copy).setVisible(false); // TODO: Copy isn't supported in graph at the moment
+        }
     }
 
     @Override

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/ItemFragment.java
@@ -119,6 +119,18 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
     private static final String COPY_DESTINATION_PREF_KEY = "copy_destination";
 
     /**
+     * If the copy flows should be disabled
+     * TODO: SERVICE DriveItems copy is not supported in graph
+     */
+    private static final boolean COPY_DISABLED = true;
+
+    /**
+     * If function calls should be disabled
+     * TODO: SERVICE Functions routing is not working correct, getting method not found
+     */
+    private static final boolean FUNCTIONS_DISABLED = true;
+
+    /**
      * The item id for this item
      */
     private String mItemId;
@@ -259,7 +271,13 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 menu.findItem(R.id.action_copy).setVisible(true);
             }
 
-            menu.findItem(R.id.action_copy).setVisible(false); // TODO: SERVICE DriveItems copy isn't supported in graph at the moment
+            if (COPY_DISABLED) {
+                menu.findItem(R.id.action_copy).setVisible(false);
+            }
+            if (FUNCTIONS_DISABLED) {
+                menu.findItem(R.id.action_view_delta).setVisible(false);
+                menu.findItem(R.id.action_create_link).setVisible(false);
+            }
         }
     }
 
@@ -457,22 +475,22 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                 @Override
                 public void onClick(final DialogInterface dialog, final int which) {
                     final BaseApplication application = (BaseApplication) getActivity()
-                                                                              .getApplication();
+                            .getApplication();
                     application.getGraphServiceClient()
                             .getMe()
-                        .getDrive()
-                        .getItems(item.id)
-                        .buildRequest()
-                        .delete(new DefaultCallback<Void>(application) {
-                            @Override
-                            public void success(final Void response) {
-                                Toast.makeText(getActivity(),
-                                        application.getString(R.string.deleted_this_item,
-                                                item.name),
-                                        Toast.LENGTH_LONG).show();
-                                getActivity().onBackPressed();
-                            }
-                        });
+                            .getDrive()
+                            .getItems(item.id)
+                            .buildRequest()
+                            .delete(new DefaultCallback<Void>(application) {
+                                @Override
+                                public void success(final Void response) {
+                                    Toast.makeText(getActivity(),
+                                            application.getString(R.string.deleted_this_item,
+                                                    item.name),
+                                            Toast.LENGTH_LONG).show();
+                                    getActivity().onBackPressed();
+                                }
+                            });
                 }
             })
             .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -504,13 +522,13 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         }
 
                         final BaseApplication application = (BaseApplication) getActivity()
-                                                                                  .getApplication();
+                                .getApplication();
                         application.getGraphServiceClient()
                                 .getMe()
-                            .getDrive()
-                            .getItems(item.id)
-                            .getCreateLink(items[selection.get()].toString(), null) // TODO: Figure out what that should be
-                            .buildRequest()
+                                .getDrive()
+                                .getItems(item.id)
+                                .getCreateLink(items[selection.get()].toString(), null) // FYI
+                                .buildRequest()
                                 .post(new DefaultCallback<Permission>(getActivity()) {
                                     @Override
                                     public void success(final Permission permission) {
@@ -564,10 +582,10 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         @Override
                         public void success(final DriveItem item) {
                             Toast.makeText(activity,
-                                              activity
-                                                  .getString(R.string.renamed_item, sourceItem.name,
-                                                                item.name),
-                                              Toast.LENGTH_LONG).show();
+                                    activity
+                                            .getString(R.string.renamed_item, sourceItem.name,
+                                                    item.name),
+                                    Toast.LENGTH_LONG).show();
                             refresh();
                             dialog.dismiss();
                         }
@@ -575,9 +593,9 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                         @Override
                         public void failure(final ClientException error) {
                             Toast.makeText(activity,
-                                              activity.getString(R.string.rename_error,
-                                                                    sourceItem.name),
-                                              Toast.LENGTH_LONG).show();
+                                    activity.getString(R.string.rename_error,
+                                            sourceItem.name),
+                                    Toast.LENGTH_LONG).show();
                             dialog.dismiss();
                         }
                     };
@@ -585,11 +603,11 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
                     updatedItem.id = sourceItem.id;
                     updatedItem.name = newName.getText().toString();
                     ((BaseApplication) activity.getApplication())
-                        .getGraphServiceClient()
+                            .getGraphServiceClient()
                             .getMe()
-                        .getDrive()
-                        .getItems(updatedItem.id)
-                        .buildRequest()
+                            .getDrive()
+                            .getItems(updatedItem.id)
+                            .buildRequest()
                             .patch(updatedItem, callback);
                 }
             })
@@ -882,6 +900,11 @@ public class ItemFragment extends Fragment implements AbsListView.OnItemClickLis
      * @param item The menu item for SetCopyDestination
      */
     private void configureSetCopyDestinationMenuItem(final MenuItem item) {
+        if (COPY_DISABLED) {
+            item.setVisible(false);
+            return;
+        }
+
         if (mItem.file != null) {
             item.setVisible(false);
         } else {

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
@@ -23,6 +23,7 @@
 package com.microsoft.onedrive.apiexplorer;
 
 import com.onedrive.sdk.concurrency.ICallback;
+import com.onedrive.sdk.core.ClientException;
 
 import android.app.Fragment;
 import android.os.Bundle;
@@ -68,6 +69,12 @@ public class PlaceholderFragment extends Fragment {
                         navigateToRoot();
                         button.setEnabled(true);
                     }
+
+                    @Override
+                    public void failure(ClientException error) {
+                        super.failure(error);
+                        button.setEnabled(true);
+                    }
                 };
                 try {
                     app.getOneDriveClient();
@@ -75,6 +82,7 @@ public class PlaceholderFragment extends Fragment {
                     button.setEnabled(true);
                 } catch (final UnsupportedOperationException ignored) {
                     app.createOneDriveClient(getActivity(), serviceCreated);
+                    button.setEnabled(true);
                 }
             }
         });

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
@@ -22,15 +22,14 @@
 
 package com.microsoft.onedrive.apiexplorer;
 
-import com.onedrive.sdk.concurrency.ICallback;
-import com.onedrive.sdk.core.ClientException;
-
 import android.app.Fragment;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+
+import com.microsoft.graph.core.ClientException;
 
 /**
  * A placeholder fragment containing a simple view.
@@ -63,27 +62,20 @@ public class PlaceholderFragment extends Fragment {
             public void onClick(final View v) {
                 button.setEnabled(false);
                 final BaseApplication app = (BaseApplication)getActivity().getApplication();
-                final ICallback<Void> serviceCreated = new DefaultCallback<Void>(getActivity()) {
+
+                app.getAuthenticationAdapter().login(getActivity(), new DefaultCallback<Void>(getActivity()) {
                     @Override
-                    public void success(final Void result) {
-                        navigateToRoot();
+                    public void success(Void aVoid) {
                         button.setEnabled(true);
+                        navigateToRoot();
                     }
 
                     @Override
-                    public void failure(ClientException error) {
-                        super.failure(error);
+                    public void failure(ClientException ex) {
                         button.setEnabled(true);
+                        super.failure(ex);
                     }
-                };
-                try {
-                    app.getOneDriveClient();
-                    navigateToRoot();
-                    button.setEnabled(true);
-                } catch (final UnsupportedOperationException ignored) {
-                    app.createOneDriveClient(getActivity(), serviceCreated);
-                    button.setEnabled(true);
-                }
+                });
             }
         });
 

--- a/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
+++ b/app/src/main/java/com/microsoft/onedrive/apiexplorer/PlaceholderFragment.java
@@ -66,13 +66,23 @@ public class PlaceholderFragment extends Fragment {
                 app.getAuthenticationAdapter().login(getActivity(), new DefaultCallback<Void>(getActivity()) {
                     @Override
                     public void success(Void aVoid) {
-                        button.setEnabled(true);
-                        navigateToRoot();
+                        getActivity().runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                button.setEnabled(true);
+                                navigateToRoot();
+                            }
+                        });
                     }
 
                     @Override
                     public void failure(ClientException ex) {
-                        button.setEnabled(true);
+                        getActivity().runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                button.setEnabled(true);
+                            }
+                        });
                         super.failure(ex);
                     }
                 });

--- a/build.gradle
+++ b/build.gradle
@@ -12,5 +12,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url  "http://dl.bintray.com/microsoftgraph/Maven"
+        }
     }
 }


### PR DESCRIPTION
Transition from the [OneDrive SDK for Android](https://github.com/OneDrive/onedrive-sdk-android/) onto the new [MSGraph SDK for Android](https://github.com/microsoftgraph/msgraph-sdk-android).
- Replaced the MSAAuthenticator with the new [MSA-Auth-For-Android-Adapter](https://github.com/microsoftgraph/msgraph-sdk-android-msa-auth-for-android-adapter), updated the application id to use the new v2 endpoint.
- Gutted a bunch of unnecessary async code from BaseApplication since the GraphServiceClient does not require interactive login anymore.
- A couple of features have been disabled since they are not yet supported on Graph.  Async methods like Copy are not yet supported, Delta does not support passing in a token parameter yet, and functions are seeing an issue within the service layer.  Once support for these features comes in those workarounds can be removed.
